### PR TITLE
Add support for partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,21 @@ module.exports.importer = function(url, prev, done) {
     url = url.replace(/^jspm:/, '')+'.scss';
 
     jspm.normalize(url).then(function(path) {
+        var stat;
+        var parts;
+        
         path = path.replace(/file:\/\/(.*?)(\.js)?$/, '$1');
         try {
-            var stat = fs.statSync(path);
-        } catch(e) {
+          stat = fs.statSync(path);
+        } catch (e) {
+          try {
+            parts = path.split('/');
+            parts[parts.length - 1] = '_' + parts[parts.length - 1];
+            path = parts.join('/');
+            stat = fs.statSync(path);
+          } catch (e) {
             return done();
+          }
         }
         if(stat.isFile()) {
             done({


### PR DESCRIPTION
Sass will automatically translate imported files with an underscore but the try catch block checks for file on the system that is an exact match of the provided file name. To allow for the use of underscore interpolation the try catch block needed a nested try for checking for a file with an underscore.

Sorry for all the commits, I was trying to squash the commit by rebasing and instead it kept creating more commits. Ugh.