### PR TITLE
Allow normalization of the npm and github registries as well

### DIFF
--- a/src/importer.js
+++ b/src/importer.js
@@ -7,12 +7,25 @@ var jspm = require('jspm')
 
 
 module.exports = function(url, prev, done) {
-    if(url.substr(0, 5) != 'jspm:')
-        return done(); // bailout
+    var registries = ['jspm', 'npm', 'github'];
+    var urlSplit = url.split(':');
+    var isRegistry = false;
 
-    url = url.replace(/^jspm:/, '')+'.scss';
+    if (urlSplit.length) {
+      var registry = urlSplit[0];
+      for (var i = 0; i < registries.length; i++) {
+        if (registry === registries[i]) {
+          url = url.replace(new RegExp('^' + registry + ':'), '')+'.scss';
+          isRegistry = true;
+          break;
+        }
+      }
+    }
 
-    jspm.normalize(url).then(function(path) {
+    if (!isRegistry) {
+      return done();
+    }
+
     jspm.normalize(url).then(function(normalizedPath) {
         var stat;
         var parts;

--- a/src/importer.js
+++ b/src/importer.js
@@ -13,25 +13,26 @@ module.exports = function(url, prev, done) {
     url = url.replace(/^jspm:/, '')+'.scss';
 
     jspm.normalize(url).then(function(path) {
+    jspm.normalize(url).then(function(normalizedPath) {
         var stat;
         var parts;
 
-        path = path.replace(/file:\/\/(.*?)(\.js)?$/, '$1');
+        normalizedPath = normalizedPath.replace(/file:\/\/(.*?)(\.js)?$/, '$1');
         try {
-            stat = fs.statSync(path);
+            stat = fs.statSync(normalizedPath);
         } catch (e) {
             try {
-                parts = path.split('/');
+                parts = normalizedPath.split('/');
                 parts[parts.length - 1] = '_' + parts[parts.length - 1];
-                path = parts.join('/');
-                stat = fs.statSync(path);
+                normalizedPath = parts.join('/');
+                stat = fs.statSync(normalizedPath);
             } catch (e) {
                 return done();
             }
         }
         if(stat.isFile()) {
             done({
-                file: path
+                file: normalizedPath
             });
         } else {
             done();

--- a/test/index.js
+++ b/test/index.js
@@ -55,9 +55,57 @@ describe('sass-jspm-importer', function() {
                 done();
             });
         });
-        it('should import partials', function(done) {
+        it('should import npm files', function(done) {
+            sass.render({
+                data: '@import "npm:fakefile";',
+                outputStyle: 'compressed',
+                importer: sassJspm.importer
+            }, function(err, result) {
+                if(err) throw err;
+
+                expect(result.css.toString()).to.equal('#id{display:block}\n');
+                done();
+            });
+        });
+        it('should import github files', function(done) {
+            sass.render({
+                data: '@import "github:fakefile";',
+                outputStyle: 'compressed',
+                importer: sassJspm.importer
+            }, function(err, result) {
+                if(err) throw err;
+
+                expect(result.css.toString()).to.equal('#id{display:block}\n');
+                done();
+            });
+        });
+        it('should import partials for jspm', function(done) {
             sass.render({
                 data: '@import "jspm:fakepartial";',
+                outputStyle: 'compressed',
+                importer: sassJspm.importer
+            }, function(err, result) {
+                if(err) throw err;
+
+                expect(result.css.toString()).to.equal('#id{display:inline}\n');
+                done();
+            });
+        });
+        it('should import partials for npm', function(done) {
+            sass.render({
+                data: '@import "npm:fakepartial";',
+                outputStyle: 'compressed',
+                importer: sassJspm.importer
+            }, function(err, result) {
+                if(err) throw err;
+
+                expect(result.css.toString()).to.equal('#id{display:inline}\n');
+                done();
+            });
+        });
+        it('should import partials for github', function(done) {
+            sass.render({
+                data: '@import "github:fakepartial";',
                 outputStyle: 'compressed',
                 importer: sassJspm.importer
             }, function(err, result) {


### PR DESCRIPTION
It feels like a waste of potential having this plugin not normalizing other registry types.
This pull request checks for npm and github, along with the already existing jspm registries