### PR TITLE
Fallback to normal css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-jspm-importer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "jspm importer module for node-sass",
   "main": "src/index.js",
   "scripts": {

--- a/src/importer.js
+++ b/src/importer.js
@@ -16,8 +16,11 @@ module.exports = function(url, prev, done) {
     jspm.normalize(url).then(function(filePath) {
         var stat;
         var parts;
+        var origFilePath;
 
-        filePath = path.resolve(fromFileURL(filePath).replace(/\.js$|\.ts$/, ''));
+        origFilePath = path.resolve(fromFileURL(filePath).replace(/\.js$/, ''));
+        filePath = origFilePath;
+
         try {
             stat = fs.statSync(filePath);
         } catch (e) {
@@ -27,7 +30,18 @@ module.exports = function(url, prev, done) {
                 filePath = parts.join(path.sep);
                 stat = fs.statSync(filePath);
             } catch (e) {
-                return done();
+                // Check if the file exists with a .css extension
+                filePath = origFilePath.replace(/\.scss$/, '.css');
+                try {
+                    stat = fs.statSync(filePath);
+                    // The file is there, with the .css extension.
+                    // Strip the .css from the filePath to have SASS build this into
+                    // the output. If we keep the .css extension here, it leaves it
+                    // a plain CSS @import for the browser to resolve.
+                    filePath = origFilePath.replace(/\.scss$/, '');
+                } catch (e) {
+                    return done();
+                }
             }
         }
         if(stat.isFile()) {
@@ -42,4 +56,3 @@ module.exports = function(url, prev, done) {
         done();
     });
 };
-


### PR DESCRIPTION
When specifying `file.css` in an import, SASS will leave it as an `@import` in the output and allow the browser to find it. Here, we allow this:
```scss
@import "jspm:package/file";
```
to look for a file under the JSPM-managed `package` path for files in this order:
* file.scss
* _file.scss
* file.css