### PR TITLE
fix(resolve): strip down path to work with jspm 0.17

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -15,6 +15,11 @@ module.exports.resolve_function = function(path_prefix) {
             jspm.normalize(exp.getValue()).then(function(respath) {
                 respath = path.resolve(fromFileURL(respath).replace(/\.js$|\.ts$/, ''));
                 var res = path.join(path_prefix, path.relative(jspm_config.pjson.packages, respath));
+                // strip any default files that 0.17 includes, we only want
+                // up to the package name
+                if (res.indexOf("@") > -1) {
+                    res = res.match(/.+@[^\/]+/)[0];
+                }
                 done(new sass.types.String(res));
             }, function(e) {
                 done(sass.compiler.types.Null());


### PR DESCRIPTION
Using jspm 0.17 with this project, the paths were resolving to the "main" file in the config. Ie, it could be:

```
/jspm_packages/npm/package@foo/index.js
```

This pull strips the extra information past the package name, ie:

```
> `"foo/bar/baz@dev/index.js".match(/.+@[^\/]+/)[0];`
< "foo/bar/baz@dev"

> `"foo/bar/baz@dev".match(/.+@[^\/]+/)[0];`
< "foo/bar/baz@dev"
```
